### PR TITLE
Support for -t=coffee

### DIFF
--- a/coffeescript/hotloader.coffee
+++ b/coffeescript/hotloader.coffee
@@ -27,9 +27,11 @@ exports.HotLoader = class
     exec "growlnotify -m \"#{message}\" -t \"#{title}\" --image #{__dirname}/nodejs.png"
   
   # File watching functions
-  run: ->
+  run: ->  
+    extName = if match = @args[@args.length - 1].match(/^-t=(.*)/) then match[1] else "js"
+    
     self = this
-    watch = exec "find . -name \"*.js\""
+    watch = exec "find . -name \"*.#{extName}\""
     watch.stdout.on "data", (data) ->
       files = data.split "\n"
       for file in files

--- a/coffeescript/hotloader.coffee
+++ b/coffeescript/hotloader.coffee
@@ -28,7 +28,13 @@ exports.HotLoader = class
   
   # File watching functions
   run: ->  
-    extName = if match = @args[@args.length - 1].match(/^-t=(.*)/) then match[1] else "js"
+    extName = "js"  # Listen to .js per default
+    
+    typeOptions = @args.filter (arg) ->
+      arg.match(/^-t=(.*)$/)
+     
+    if typeOptions.length > 0 && match = typeOptions[typeOptions.length - 1].match(/^-t=(.*)/)
+      extName = match[1]
     
     self = this
     watch = exec "find . -name \"*.#{extName}\""

--- a/javascript/hotloader.js
+++ b/javascript/hotloader.js
@@ -28,8 +28,14 @@ exports.HotLoader = (function() {
     return exec("growlnotify -m \"" + (message) + "\" -t \"" + (title) + "\" --image " + (__dirname) + "/nodejs.png");
   };
   _a.prototype.run = function() {
-    var extName, match, self, watch;
-    extName = (match = this.args[this.args.length - 1].match(/^-t=(.*)/)) ? match[1] : "js";
+    var extName, match, self, typeOptions, watch;
+    extName = "js";
+    typeOptions = this.args.filter(function(arg) {
+      return arg.match(/^-t=(.*)$/);
+    });
+    if (typeOptions.length > 0 && (match = typeOptions[typeOptions.length - 1].match(/^-t=(.*)/))) {
+      extName = match[1];
+    }
     self = this;
     watch = exec("find . -name \"*." + (extName) + "\"");
     watch.stdout.on("data", function(data) {

--- a/javascript/hotloader.js
+++ b/javascript/hotloader.js
@@ -1,13 +1,13 @@
-var _ctor, exec, fs, spawn;
+var _a, exec, fs, spawn;
 exec = require('child_process').exec;
 spawn = require('child_process').spawn;
 fs = require('fs');
 exports.HotLoader = (function() {
-  _ctor = function(args) {
+  _a = function(args) {
     this.args = args;
     return this;
   };
-  _ctor.prototype.output = function(message, good) {
+  _a.prototype.output = function(message, good) {
     var output, self;
     self = this;
     output = "\033[0;30mhotnode: \033[1;";
@@ -19,37 +19,38 @@ exports.HotLoader = (function() {
     output += ("" + (message) + "\033[m");
     return console.log(output);
   };
-  _ctor.prototype.stderrOutput = function(message) {
+  _a.prototype.stderrOutput = function(message) {
     var output;
     output = ("\033[0;31m" + (message) + "\033[m");
     return console.log(output);
   };
-  _ctor.prototype.growl = function(message, title) {
+  _a.prototype.growl = function(message, title) {
     return exec("growlnotify -m \"" + (message) + "\" -t \"" + (title) + "\" --image " + (__dirname) + "/nodejs.png");
   };
-  _ctor.prototype.run = function() {
-    var self, watch;
+  _a.prototype.run = function() {
+    var extName, match, self, watch;
+    extName = (match = this.args[this.args.length - 1].match(/^-t=(.*)/)) ? match[1] : "js";
     self = this;
-    watch = exec("find . -name \"*.js\"");
+    watch = exec("find . -name \"*." + (extName) + "\"");
     watch.stdout.on("data", function(data) {
-      var _i, _len, _ref, _result, files;
+      var _b, _c, _d, _e, files;
       files = data.split("\n");
-      _result = []; _ref = files;
-      for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+      _b = []; _d = files;
+      for (_c = 0, _e = _d.length; _c < _e; _c++) {
         (function() {
-          var file = _ref[_i];
-          return _result.push(file ? fs.watchFile(file, {
+          var file = _d[_c];
+          return _b.push(file ? fs.watchFile(file, {
             interval: 100
           }, function(prev, curr) {
             return Number(new Date(prev.mtime)) !== Number(new Date(curr.mtime)) ? self.restartProcess(file.replace(/\.\//, "")) : null;
           }) : null);
         })();
       }
-      return _result;
+      return _b;
     });
     return this.startProcess();
   };
-  _ctor.prototype.startProcess = function() {
+  _a.prototype.startProcess = function() {
     var self;
     self = this;
     this.process = spawn("node", this.args.slice(2), {
@@ -64,9 +65,9 @@ exports.HotLoader = (function() {
     this.output("Node.js process restarted", true);
     return this.growl("Node.js process restarted", "Hotnode");
   };
-  _ctor.prototype.restartProcess = function(filename) {
-    var _ref;
-    if (typeof (_ref = this.process) !== "undefined" && _ref !== null) {
+  _a.prototype.restartProcess = function(filename) {
+    var _b;
+    if (typeof (_b = this.process) !== "undefined" && _b !== null) {
       try {
         this.process.kill("SIGKILL");
       } catch (e) {
@@ -76,5 +77,5 @@ exports.HotLoader = (function() {
     this.output("" + (filename) + " changed", false);
     return this.startProcess();
   };
-  return _ctor;
+  return _a;
 })();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
 , "homepage" : "http://www.filshmedia.net"
 , "author" : "Sascha Gehlich <contact@filshmedia.net> (http://www.filshmedia.net)"
 , "contributors" :
-  [ "Sebastian Deutsch <sebastian.deutsch@9elements.com> (http://9elements.com)" ]
+  [ 
+      "Sebastian Deutsch <sebastian.deutsch@9elements.com> (http://9elements.com)"
+    , "Andreas Wolff <andreas@phunkwork.com> (http://phunkwork.com)"
+  ]
 , "repository" :
   { "type" : "git"
   , "url" : "http://github.com/saschagehlich/hotnode"


### PR DESCRIPTION
Hi.

I've added support for specifying different files types to watch for.
So you can now pass  `-t=coffee` to make hotnode listen to changes in coffee files.

```
hotnode file.js -t=coffee
```

This is important if you have a boot.js file which loads the coffee-script compiler, which in turn, allows you to build the rest of your application using Coffeescript..
