### PR TITLE
Prevent notify-send notifications from piling up in gnome-shell

### DIFF
--- a/coffeescript/hotloader.coffee
+++ b/coffeescript/hotloader.coffee
@@ -45,7 +45,7 @@ exports.HotLoader = class
 
   growl: (message, title) ->
     if process.env.DESKTOP_SESSION and process.env.DESKTOP_SESSION.indexOf("gnome") != -1
-      exec "notify-send --icon #{__dirname}/nodejs.png \"#{title}\" \"#{message}\" "
+      exec "notify-send --hint=int:transient:1 --icon #{__dirname}/nodejs.png \"#{title}\" \"#{message}\" "
     else
       exec "growlnotify -m \"#{message}\" -t \"#{title}\" --image #{__dirname}/nodejs.png"
 


### PR DESCRIPTION
Essentially this fixed this issue outlined better here for Gnome Shell users and notify-send:

https://bugzilla.redhat.com/show_bug.cgi?id=693207
